### PR TITLE
Added plugin signing functionality

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## [Unreleased]
+### Added
+- Added [plugin signing](https://plugins.jetbrains.com/docs/intellij/plugin-signing.html) functionality
+
 ### Changed
 - Updated _org.jetbrains.intellij_ plugin from 1.1.4 to 1.1.6
 - Updated _org.jetbrains.changelog_ plugin from 1.2.1 to 1.3.0

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,4 @@
 import org.jetbrains.changelog.date
-import org.jetbrains.changelog.markdownToHTML
 
 fun properties(key: String) = project.findProperty(key).toString()
 
@@ -67,6 +66,12 @@ tasks {
         keepUnreleasedSection.set(true)
         unreleasedTerm.set("[Unreleased]")
         groups.set(listOf("Added", "Changed", "Deprecated", "Removed", "Fixed", "Security"))
+    }
+
+    signPlugin {
+        certificateChain.set(System.getenv("CERTIFICATE_CHAIN"))
+        privateKey.set(System.getenv("PRIVATE_KEY"))
+        password.set(System.getenv("PRIVATE_KEY_PASSWORD"))
     }
 
     publishPlugin {


### PR DESCRIPTION
New Gradle task was added according to [plugin signing](https://plugins.jetbrains.com/docs/intellij/plugin-signing.html) requirements. It will remove Jetbrains warnings about plugin insecurity when deploying via pipeline.
