### PR TITLE
Support Intellij 2021.3 Platform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,16 @@
 # Changelog
 
 ## [Unreleased]
+### Breaking Changes
+- Updated minimal Intellij Platform version to 2021.3
+
 ### Added
 - Added [plugin signing](https://plugins.jetbrains.com/docs/intellij/plugin-signing.html) functionality
 
 ### Changed
-- Updated _org.jetbrains.intellij_ plugin from 1.1.4 to 1.1.6
-- Updated _org.jetbrains.changelog_ plugin from 1.2.1 to 1.3.0
+- Updated _org.jetbrains.intellij_ plugin from 1.1.4 to 1.2.1
+- Updated _org.jetbrains.changelog_ plugin from 1.2.1 to 1.3.1
+- Moved to Scala 3
 - Removed usage of Reflection API in DBMS registration
 
 ## [0.0.1] - 2021-08-13

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,12 +7,12 @@ pluginName = Tarantool Database
 pluginVersion = 0.1.0
 
 pluginSinceBuild = 212
-pluginUntilBuild = 212.*
+pluginUntilBuild = 213.*
 
-pluginVerifierIdeVersions = IU-2021.2,PY-2021.2,GO-2021.2,CL-2021.2
+pluginVerifierIdeVersions = PY-213.5281.17,GO-213.5449.26,CL-213.5605.4,IU-213.5605.12
 
 platformType = IU
-platformVersion = 2021.2.2
+platformVersion = LATEST-EAP-SNAPSHOT
 platformDownloadSources = true
 
 platformPlugins = com.intellij.database

--- a/src/main/scala/icons/TarantoolIcons.java
+++ b/src/main/scala/icons/TarantoolIcons.java
@@ -11,7 +11,7 @@ public interface TarantoolIcons {
 
     static Icon load(String path) {
         Objects.requireNonNull(path);
-        Icon icon = IconLoader.getIcon("/icons/" + path);
+        Icon icon = IconLoader.getIcon("/icons/" + path, TarantoolIcons.class);
         return Objects.requireNonNull(icon);
     }
 

--- a/src/main/scala/io/tarantool/idea/plugin/sql/DbmsHolder.java
+++ b/src/main/scala/io/tarantool/idea/plugin/sql/DbmsHolder.java
@@ -2,8 +2,41 @@ package io.tarantool.idea.plugin.sql;
 
 import com.intellij.database.Dbms;
 import icons.TarantoolIcons;
-import static io.tarantool.idea.plugin.sql.Constants.*;
+
+import javax.swing.*;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.util.function.Supplier;
+
+import static io.tarantool.idea.plugin.sql.Constants.dbmsTarantool;
+import static io.tarantool.idea.plugin.sql.Constants.tarantool;
 
 public final class DbmsHolder {
-    public static final Dbms DBMS = Dbms.create(dbmsTarantool(), tarantool(), TarantoolIcons.Tarantool13);
+
+    public static final Dbms DBMS;
+
+    static {
+        //TODO: Remove this backward compatibility trick after Intellij 2021.3 Release
+        MethodHandles.Lookup lookup = MethodHandles.lookup();
+        try {
+            Dbms dbms;
+            try {
+                final var types = MethodType.methodType(Dbms.class, String.class, String.class, Icon.class);
+                final var mh = lookup.findStatic(Dbms.class, "create", types);
+                dbms = (Dbms) mh.invokeExact(dbmsTarantool(), tarantool(), TarantoolIcons.Tarantool13);
+            } catch (final NoSuchMethodException e) {
+                final Supplier<Icon> createIcon = () -> TarantoolIcons.Tarantool13;
+                final var types = MethodType.methodType(Dbms.class, String.class, String.class, Supplier.class);
+                final var mh = lookup.findStatic(Dbms.class, "create", types);
+                dbms = (Dbms) mh.invokeExact(dbmsTarantool(), tarantool(), createIcon);
+            }
+            DBMS = dbms;
+        } catch (final Throwable e) {
+            throw new ExceptionInInitializerError(e);
+        }
+    }
+
+    private DbmsHolder() {
+        throw new AssertionError("Suppress default constructor for noninstantiability");
+    }
 }


### PR DESCRIPTION
Change minimal supported platform version to 2021.3 due to breaking changes in API.

## Description
Replaced verification IDEs with 213.* versions.
Used new DBMS factory method instead of removed.
Used new IconLoader method instead of removed.

## Motivation and Context
Intellij 2021.3 is releasing soon; we should migrate the plugin to the new platform version to keep up.

## How has this been tested?
Ran IDE locally and verified via Gradle plugin.

## Types of changes
What types of changes does your code introduce? Put an `x` in all the boxes that apply: 
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality not to work as expected)

## Checklist:
Go over all the following points, and put an `x` in all the boxes that apply.
If you're unsure about any of these, don't hesitate to ask. We're here to help!
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
